### PR TITLE
feat: add interface-to-record exhibit

### DIFF
--- a/src/exhibits/interface-to-record/exhibit-a.ts
+++ b/src/exhibits/interface-to-record/exhibit-a.ts
@@ -1,0 +1,9 @@
+type A<T extends Record<string, unknown>> = T;
+
+interface User {
+  user: string;
+}
+
+// Why does interface not fit Record<string, unknown>?
+// @ts-expect-error
+type B = A<User>


### PR DESCRIPTION
Why does interface not fit Record<string, unknown>?